### PR TITLE
Rename initialize to initializePackage to avoid breakage in Atom 1.14

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -69,9 +69,9 @@ class Main
 
   isPackageActive: (findPackage) =>
     if findPackage.name == 'find-and-replace'
-      @initialize()
+      @initializePackage()
 
-  initialize: ->
+  initializePackage: ->
     if @activated
       # Check for active find-and-replace package
       @model = atom.packages.getActivePackage('find-and-replace')
@@ -95,7 +95,7 @@ class Main
       @activated = true
       @subscriptions = new CompositeDisposable
       @subscriptions.add atom.packages.onDidActivatePackage(@isPackageActive)
-      @initialize()
+      @initializePackage()
     else
       @activated = false
       @subscriptions.dispose()


### PR DESCRIPTION
As of Atom 1.14, any method named `initialize` on the main module of a package will be automatically invoked by Atom before calling `activate`. You can read more about the change in this [pull request to Atom's documentation](https://github.com/atom/flight-manual.atom.io/pull/300/files).

Since your package's `initialize` method wasn't written with this behavior in mind, we've renamed it for you to avoid unexpected breakage.

Atom 1.14 should reach the beta channel in early January 2017 and will be on stable in early February 2017. Please merge and test out this PR before then to prevent issues, and let us know if you have any questions.

Thanks for your contributions to the Atom community! 🙇 

/cc @Aakash1312 